### PR TITLE
HOTFIX | pin pipenv to new version

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -42,7 +42,7 @@ if [ ! "$SKIP_PIPENV_INSTALL" ]; then
             mcount "buildvar.PIP_EXTRA_INDEX_URL"
         fi
 
-        PIPENV_VERSION='2020.11.15'
+        PIPENV_VERSION='2022.9.24'
 
         # Install pipenv.
         # Due to weird old pip behavior and pipenv behavior, pipenv upgrades pip


### PR DESCRIPTION
Currently pipenv is not working within Heroku build. Hopefully a new version will help resolve the issue
